### PR TITLE
Update default search prompt to broader job titles

### DIFF
--- a/scripts/run_daily.sh
+++ b/scripts/run_daily.sh
@@ -39,7 +39,7 @@ fi
 cd "$PROJECT_DIR"
 
 python3 src/scrape.py \
-    --prompt "${SCRAPE_PROMPT:-AI/ML Data Scientist at tech companies}" \
+    --prompt "${SCRAPE_PROMPT:-machine learning scientist, machine learning engineer, data scientist}" \
     --num-pages "${NUM_PAGES:-10}" \
     --headless \
     "$@"   # pass any extra CLI flags straight through (e.g. --no-hf, --no-s3)

--- a/src/scrape.py
+++ b/src/scrape.py
@@ -357,7 +357,7 @@ def save_to_hf(df: pd.DataFrame, repo_id: str, readme_path: str, hf_token: str) 
 def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(prog="linkedin_scraper", description="Scrape LinkedIn jobs to S3 and Hugging Face.")
     p.add_argument(
-        "-p", "--prompt", default="Data Scientist & Machine Learning Engineer",
+        "-p", "--prompt", default="machine learning scientist, machine learning engineer, data scientist",
         help="Search prompt describing the jobs to scrape"
         )
     p.add_argument(


### PR DESCRIPTION
## Summary
- Updated default search prompt in both `run_daily.sh` and `scrape.py` from `"AI/ML Data Scientist at tech companies"` to `"machine learning scientist, machine learning engineer, data scientist"`
- Fixes a discrepancy where the shell script default was overriding the Python default with a stale value

## Test plan
- [x] Verified both files use the new prompt consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)