### PR TITLE
Refresh ops, config, and docs for the local pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,12 @@
-SSM_REGION=us-west-2
+# Required for S3/HF export (scraping itself runs without these)
 S3_PREFIX=s3://your-bucket-name/data
 HF_REPO_ID=your-hf-username/your-dataset-name
+
+# Optional overrides — defaults live in src/config.py
+#SSM_REGION=us-west-2
+#SCRAPE_QUERIES=machine learning scientist, machine learning engineer, data scientist   # ";"-separated queries
+#TIME_WINDOW=r86400          # f_TPR filter: r86400 = past 24h, r604800 = past week, empty = all
+#MAX_PAGES=10
+#MAX_DETAIL_VISITS=300
+#DB_PATH=data/jobs.db
+#PROFILE_DIR=chrome_user_data

--- a/.gitignore
+++ b/.gitignore
@@ -1,31 +1,31 @@
-.DS_Store
-*.pkl
-*.log
-**/*.json
-**/*.env
-logs/
-infra/*.plist
-
-text*
-tensorflow*
-
-.ipynb_checkpoints
-**/notebook/
-**/data/
-**/driver/
-**/config.yml
-**/*.zip
-**/*.csv
-
-bazel
-src/scrape_dev.py
-
-**/.venv
-src/test_cookie.py
-**/__pycache__/
-**/chrome_user_data/
-install_chrome_driver.sh
+# secrets & env
 **/.env
+**/*.env
+
+# scraper state (session, database, logs)
+**/chrome_user_data/
+**/data/
+*.db
+logs/
+*.log
+
+# local-only tools & experiments
 app.py
+**/notebook/
+**/driver/
 CLAUDE.md
 
+# python
+**/__pycache__/
+**/.venv
+.pytest_cache/
+.ipynb_checkpoints
+
+# local exports / dumps
+**/*.csv
+**/*.json
+**/*.zip
+
+# macOS & scheduling
+.DS_Store
+infra/*.plist

--- a/README.md
+++ b/README.md
@@ -1,41 +1,26 @@
 # LinkedIn Job Scraper
 
-A lightweight, production-grade Job scraping pipeline for data science / machine learning jobs on LinkedIn
+A lightweight Job scraping pipeline for data science / machine learning jobs on LinkedIn
 
 ## Where to Find the Data
 **Huggingface**: [`ryang2/linkedin-job-scrape`](https://huggingface.co/datasets/ryang2/linkedin-job-scrape) on Hugging Face Hub
 
 ## Problem & Requirements
 
-**Goal:** build a continuously growing, analysis-ready dataset of DS/ML job postings with the most complete schema the LinkedIn UI exposes — without manual effort.
+**Goal:** build a continuously growing, analysis-ready dataset of DS/ML job postings with the most complete and up-to-date schema from LinkedIn UI.
 
 **Functional requirements**
-- Scrape configurable search queries daily; capture card metadata, full descriptions, and every detail-page field available (salary, applicant insights, company insights, hiring team)
-- Deduplicate across runs: never re-scrape a known job; track when each posting was first/last seen
+- Scrape daily; capture card metadata, full descriptions, and every detail-page field available (salary, applicant insights, company insights, hiring team)
+- Dedup across runs: never re-scrape a known job; track when each posting was first/last seen
 - Persist locally (SQLite) and publish daily snapshots (S3 CSV + HF split)
 
 **Non-functional requirements**
-- Fast: minutes per run, not tens of minutes — incremental visits, no fixed sleeps, blocked images/fonts
-- Unattended on a laptop: persistent login session (no per-run login/2FA), resumable after crash/sleep
+- Fast: less than 10 minutes per run — incremental visits, no fixed sleeps, blocked images/fonts
+- Unattended on laptop: persistent login session (no per-run login/2FA), resumable after crash/sleep
 - Data quality as a feature: typed schema, missing = NULL, per-field completeness metrics logged every run, parsers unit-tested against captured fixtures
 - Resilient to LinkedIn DOM churn: anchor on stable `componentkey` attributes, tripwire exit codes, Playwright traces for post-mortem
 
 ## Architecture
-
-### System view
-
-```mermaid
-flowchart LR
-    LD[launchd<br/>daily 22:00] --> M["main.py scrape"]
-    M -->|Playwright,<br/>persistent session| LI[linkedin.com]
-    M <-->|"seen? / upsert"| DB[(SQLite<br/>data/jobs.db)]
-    DB --> EX[export.py]
-    EX --> S3[(S3 CSV snapshot)]
-    EX --> HF[(HF Hub dataset)]
-    CP[chrome_user_data/<br/>login cookie] -.-> M
-```
-
-### Run workflow
 
 ```mermaid
 flowchart TD
@@ -94,20 +79,24 @@ flowchart TD
 
 ## Data Model
 
-One row per job posting (`Job` dataclass → `jobs` table; missing values are NULL):
+One row per job posting (`Job` dataclass → `jobs` table; missing values are NULL). The **Access** column marks where a field comes from: `Public` = visible without an account, `Login` = only visible signed in, `Premium` = requires a Premium subscription.
 
-| Group | Fields |
-|---|---|
-| Identity | `job_id` (PK), `job_url`, `search_query`, `scrape_dt` |
-| Core | `job_title`, `company_name`, `location`, `workplace_type` (Remote/Hybrid/On-site), `employment_type`, `job_description`, `logo_url`, `verified_job` |
-| Salary | `salary_raw`, `salary_min`, `salary_max`, `salary_period` — parsed from card and/or description |
-| Posting meta | `posted_age_text`, `posted_at_estimate`, `is_reposted`, `is_promoted`, `apply_type` (easy/external), `applicants_clicked`, `benefits` |
-| Company | `about_company`, `company_headcount`, `headcount_growth_2y`, `median_tenure` |
-| Applicant insights (Premium) | `applicants_total`, `applicants_past_day`, `seniority_dist` (JSON), `education_dist` (JSON) |
-| People | `hiring_team` (JSON: name + title) |
-| Store meta | `first_seen`, `last_seen`, `times_seen` |
+| Group | Access | Fields |
+|---|---|---|
+| Identity | Public | `job_id` (PK), `job_url`, `search_query`, `scrape_dt` |
+| Core | Public | `job_title`, `company_name`, `location`, `workplace_type` (Remote/Hybrid/On-site), `employment_type`, `job_description`, `logo_url`, `verified_job` |
+| Salary | Public | `salary_raw`, `salary_min`, `salary_max`, `salary_period` — parsed from card and/or description |
+| Posting meta | Public | `posted_age_text`, `posted_at_estimate`, `is_reposted`, `benefits` |
+| Posting meta | Login | `is_promoted`, `apply_type` (easy/external), `applicants_clicked` |
+| Company | Public | `about_company` |
+| Company insights | Premium | `company_headcount`, `headcount_growth_2y`, `median_tenure` |
+| Applicant insights | Premium | `applicants_total`, `applicants_past_day`, `seniority_dist` (JSON), `education_dist` (JSON) |
+| People | Login | `hiring_team` (JSON: name + title) |
+| Store meta | Derived | `first_seen`, `last_seen`, `times_seen` |
 
-**Exports** (unchanged contracts): S3 `{S3_PREFIX}/linkedin-scrape_{ts}.csv`; HF one split per run (`ts` with underscores), dataset card synced from `hf_dataset_readme.md`. License: BigScience OpenRAIL-M — research/educational use.
+**Privacy rule:** `Login` and `Premium` fields are gathered through a personal account and are personalized/gated — they stay in the local SQLite store and the private S3 snapshots only, and are **excluded from the public Hugging Face dataset** (`PRIVATE_FIELDS` in `src/schemas.py`, applied by `public_view()` in `src/export.py`).
+
+**Exports**: S3 `{S3_PREFIX}/linkedin-scrape_{ts}.csv` (full schema, private bucket); HF one split per run (`ts` with underscores, **public fields only**), dataset card synced from `hf_dataset_readme.md`. License: BigScience OpenRAIL-M — research/educational use.
 
 ## Configuration
 
@@ -143,6 +132,6 @@ python src/main.py export --date 2026-07-18                    # re-export a day
 
 AWS credentials (`aws configure`) are needed only for exports (S3 write + SSM read of the HF token).
 
-**Schedule it:** copy `infra/linkedin-scraper.plist.example` to `~/Library/LaunchAgents/`, fix the two paths, `launchctl load` it. launchd runs the job at 22:00 daily (or on wake if the machine was asleep); output lands in `logs/scrape.log`. Failed runs save a Playwright trace to `logs/traces/` — inspect with `playwright show-trace <file>`.
+**Schedule:** copy `infra/linkedin-scraper.plist.example` to `~/Library/LaunchAgents/`, fix the two paths, `launchctl load` it. launchd runs the job at 22:00 daily (or on wake if the machine was asleep); output lands in `logs/scrape.log`. Failed runs save a Playwright trace to `logs/traces/` — inspect with `playwright show-trace <file>`.
 
 **Run tests:** `pytest` — parsers are validated against text fixtures captured from the live site, so LinkedIn layout changes can be fixed by updating a fixture and re-running.

--- a/hf_dataset_readme.md
+++ b/hf_dataset_readme.md
@@ -1,27 +1,13 @@
 ---
-dataset_info:
-  features:
-  - name: job_id
-    dtype: string
-  - name: job_title
-    dtype: string
-  - name: company_name
-    dtype: string
-  - name: location
-    dtype: string
-  - name: salary
-    dtype: string
-  - name: logo_url
-    dtype: string
-  - name: job_description
-    dtype: string
-  - name: scrape_dt
-    dtype: string
 configs:
 - config_name: default
   data_files:
   - split: train
-    path: 
+    path: "data/2026_*.parquet"
+- config_name: legacy
+  data_files:
+  - split: train
+    path:
     - "data/2023_*.parquet"
     - "data/2024_*.parquet"
   - split: test
@@ -35,9 +21,20 @@ This dataset is released under the **BigScience OpenRAIL-M license**.
 It is provided strictly for **research and educational purposes**.  
 Any form of **commercial use, redistribution, or use for profit-oriented applications is prohibited**.
 
+## Data & Privacy
+
+The dataset contains **publicly visible job-posting fields only** (title, company, location,
+description, salary where posted, etc.). Fields that are login-gated or Premium-gated on
+LinkedIn — applicant statistics, company insights, hiring-team contacts — are **not published**
+here. Missing values are empty/NULL rather than sentinel strings.
+
+Two configs, split along a schema change:
+- **`default`** — data from 2026-07 onward, full public schema (the Hub infers columns from the parquet files)
+- **`legacy`** — 2023–2025 data with the original 8-column schema
+  (`job_id`, `job_title`, `company_name`, `location`, `salary`, `logo_url`, `job_description`, `scrape_dt`)
+
 ## Source Code & Contributions
 
-The dataset was generated using a custom Python + Selenium scraper.
+The dataset was generated using a custom Python + Playwright scraper.
 If you'd like to run the scraper under your own LinkedIn account, you can find the source on Github: [🔗 scrape-linkedin-ds-jobs](https://github.com/ryq99/scrape-linkedin-ds-jobs.git).
 The repo is actively maintained to keep the scraper working with LinkedIn’s changes.
-Contributions are always welcome!

--- a/infra/linkedin-scraper.plist.example
+++ b/infra/linkedin-scraper.plist.example
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd schedule for the LinkedIn scraper.
+
+  Install:
+    cp infra/linkedin-scraper.plist.example ~/Library/LaunchAgents/com.<you>.linkedin-scraper.plist
+    # edit the two /path/to/ds_jobs paths below, then:
+    launchctl load ~/Library/LaunchAgents/com.<you>.linkedin-scraper.plist
+-->
+<plist version="1.0">
+<dict>
+
+    <key>Label</key>
+    <string>com.user.linkedin-scraper</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/path/to/ds_jobs/scripts/run_daily.sh</string>
+    </array>
+
+    <!-- Run daily at 10:00 pm; launchd runs it on wake if the machine was asleep -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>22</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>StandardOutPath</key>
+    <string>/path/to/ds_jobs/logs/scrape.log</string>
+    <key>StandardErrorPath</key>
+    <string>/path/to/ds_jobs/logs/scrape.log</string>
+
+</dict>
+</plist>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = src
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-tqdm
+playwright
 pandas
-selenium
-webdriver_manager
 boto3
-s3fs
 awswrangler
 datasets
 huggingface_hub
+pytest

--- a/scripts/run_daily.sh
+++ b/scripts/run_daily.sh
@@ -30,8 +30,9 @@ if [[ -f "$ENV_FILE" ]]; then
 fi
 
 cd "$PROJECT_DIR"
-python3 src/main.py scrape "$@"
+# `|| EXIT_CODE=$?` keeps set -e from aborting before the footer logs on failure
+EXIT_CODE=0
+python3 src/main.py scrape "$@" || EXIT_CODE=$?
 
-EXIT_CODE=$?
 echo "===== Scraper finished at $(date -u '+%Y-%m-%d %H:%M:%S UTC') (exit $EXIT_CODE) ====="
 exit $EXIT_CODE

--- a/scripts/run_daily.sh
+++ b/scripts/run_daily.sh
@@ -3,46 +3,34 @@
 # run_daily.sh — Run the LinkedIn job scraper locally.
 #
 # Usage:
-#   ./scripts/run_daily.sh              # uses defaults in .env
-#   ./scripts/run_daily.sh --no-headless  # open visible browser (for debugging)
+#   ./scripts/run_daily.sh              # daily incremental scrape (past 24h)
+#   ./scripts/run_daily.sh --headed     # visible browser (for debugging)
 #
-# Cron example (every day at 10 pm):
-#   0 22 * * * /path/to/ds_jobs/scripts/run_daily.sh >> /path/to/ds_jobs/logs/scrape.log 2>&1
+# Scheduled via launchd: see infra/linkedin-scraper.plist.example
 # ---------------------------------------------------------------------------
 
 set -euo pipefail
 
-# ── Resolve the project root (works whether called from any cwd) ──────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 LOG_DIR="$PROJECT_DIR/logs"
 mkdir -p "$LOG_DIR"
 
 echo "===== LinkedIn scraper started at $(date -u '+%Y-%m-%d %H:%M:%S UTC') ====="
-echo "Project: $PROJECT_DIR"
 
-# ── Activate virtualenv if present ───────────────────────────────────────────
 VENV="$PROJECT_DIR/.venv"
 if [[ -d "$VENV" ]]; then
-    echo "Activating virtualenv: $VENV"
     # shellcheck disable=SC1091
     source "$VENV/bin/activate"
 fi
 
-# ── Load environment variables ────────────────────────────────────────────────
 ENV_FILE="$PROJECT_DIR/.env"
 if [[ -f "$ENV_FILE" ]]; then
     set -a; source "$ENV_FILE"; set +a
 fi
 
-# ── Run the scraper ───────────────────────────────────────────────────────────
 cd "$PROJECT_DIR"
-
-python3 src/scrape.py \
-    --prompt "${SCRAPE_PROMPT:-machine learning scientist, machine learning engineer, data scientist}" \
-    --num-pages "${NUM_PAGES:-10}" \
-    --headless \
-    "$@"   # pass any extra CLI flags straight through (e.g. --no-hf, --no-s3)
+python3 src/main.py scrape "$@"
 
 EXIT_CODE=$?
 echo "===== Scraper finished at $(date -u '+%Y-%m-%d %H:%M:%S UTC') (exit $EXIT_CODE) ====="


### PR DESCRIPTION
## Summary
Everything except the new scraper code itself (`src/` + `tests/` follow in the next PR):

- **scripts/run_daily.sh** — now invokes `src/main.py scrape` (venv/.env wrapper unchanged)
- **infra/linkedin-scraper.plist.example** — tracked, sanitized launchd template (daily 22:00)
- **pytest.ini** — `pythonpath = src` so tests import the flat modules
- **requirements.txt** — playwright + pytest in; selenium, webdriver_manager, s3fs, tqdm out
- **.env.example** — only required vars active; defaults documented as commented overrides
- **.gitignore** — reorganized; adds `.pytest_cache/` and `*.db`, drops dead Selenium-era entries
- **hf_dataset_readme.md** — removes the drift-prone hand-listed feature block; fixes stale year globs that made 2026 splits invisible; splits configs along the schema boundary (`default` = 2026+, `legacy` = 2023–2025)
- **README** — data model now labels field access tiers (Public/Login/Premium) with the privacy rule: login/Premium-gated fields stay in SQLite + private S3 and are excluded from the public HF dataset

## Note
`run_daily.sh` references `src/main.py`, which lands in the follow-up scraper PR — merge that one before the next scheduled run picks up these scripts on a fresh clone.