### PR TITLE
Promote develop → main: unattended wake/sleep cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [Running Locally](#running-locally) for exports, scheduling, and tests.
 
 **Non-functional requirements**
 - Fast: less than 10 minutes per run — incremental visits, no fixed sleeps, blocked images/fonts
-- Unattended on laptop: persistent login session (no per-run login/2FA), resumable after crash/sleep
+- Unattended on laptop: persistent login session (no per-run login/2FA); scheduled runs self-wake the Mac (`pmset`), stay awake through upload (`caffeinate`), then sleep; resumable after crash/sleep
 - Data quality as a feature: typed schema, missing = NULL, per-field completeness metrics logged every run, parsers unit-tested against captured fixtures
 - Resilient to LinkedIn DOM churn: anchor on stable `componentkey` attributes, tripwire exit codes, Playwright traces for post-mortem
 
@@ -159,6 +159,12 @@ python src/main.py export --date 2026-07-18                    # re-export a day
 
 AWS credentials (`aws configure`) are needed only for exports (S3 write + SSM read of the HF token).
 
-**Schedule:** copy `infra/linkedin-scraper.plist.example` to `~/Library/LaunchAgents/`, fix the two paths, `launchctl load` it. launchd runs the job at 22:00 daily (or on wake if the machine was asleep); output lands in `logs/scrape.log`. Failed runs save a Playwright trace to `logs/traces/` — inspect with `playwright show-trace <file>`.
+**Schedule (unattended overnight run):** three pieces, because launchd alone does *not* wake a sleeping Mac — it only runs the job once the machine is awake.
+
+1. **Wake** — install a daily hardware wake once: `sudo ./scripts/setup_wake_schedule.sh` (`pmset repeat wake` at 21:58; undo with `sudo pmset repeat cancel`, inspect with `pmset -g sched`).
+2. **Run** — copy `infra/linkedin-scraper.plist.example` to `~/Library/LaunchAgents/`, fix the two paths, `launchctl load` it. launchd fires `run_daily.sh --sleep-after` at 22:00; output lands in `logs/scrape.log`.
+3. **Stay awake, then sleep** — the wrapper runs the scrape under `caffeinate` so idle sleep can't kill it mid-run, then `--sleep-after` returns the Mac to sleep once the upload finishes (manual runs omit the flag, so they never sleep your machine).
+
+Failed runs save a Playwright trace to `logs/traces/` — inspect with `playwright show-trace <file>`.
 
 **Run tests:** `pytest` — parsers are validated against text fixtures captured from the live site, so LinkedIn layout changes can be fixed by updating a fixture and re-running.

--- a/infra/linkedin-scraper.plist.example
+++ b/infra/linkedin-scraper.plist.example
@@ -4,6 +4,13 @@
 <!--
   launchd schedule for the LinkedIn scraper.
 
+  IMPORTANT — launchd does NOT wake a sleeping Mac. StartCalendarInterval only
+  runs the job when the machine is already awake (or on its next wake). To wake
+  the Mac for the overnight run, install the daily wake ONCE:
+    sudo ./scripts/setup_wake_schedule.sh      # pmset repeat wake @ 21:58
+  The wrapper then runs the scrape under `caffeinate` (stays awake through the
+  upload) and, because of the --sleep-after arg below, sleeps the Mac when done.
+
   Install:
     cp infra/linkedin-scraper.plist.example ~/Library/LaunchAgents/com.<you>.linkedin-scraper.plist
     # edit the two /path/to/ds_jobs paths below, then:
@@ -19,9 +26,12 @@
     <array>
         <string>/bin/bash</string>
         <string>/path/to/ds_jobs/scripts/run_daily.sh</string>
+        <string>--sleep-after</string>
     </array>
 
-    <!-- Run daily at 10:00 pm; launchd runs it on wake if the machine was asleep -->
+    <!-- Fire daily at 10:00 pm. The Mac is woken at 21:58 by the pmset repeat
+         wake from setup_wake_schedule.sh (run that once); this only sets when
+         launchd runs the job, it does not wake the machine on its own. -->
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>

--- a/scripts/run_daily.sh
+++ b/scripts/run_daily.sh
@@ -3,13 +3,31 @@
 # run_daily.sh — Run the LinkedIn job scraper locally.
 #
 # Usage:
-#   ./scripts/run_daily.sh              # daily incremental scrape (past 24h)
-#   ./scripts/run_daily.sh --headed     # visible browser (for debugging)
+#   ./scripts/run_daily.sh                 # daily incremental scrape (past 24h)
+#   ./scripts/run_daily.sh --headed        # visible browser (for debugging)
+#   ./scripts/run_daily.sh --sleep-after   # put the Mac to sleep when done
+#                                          # (used by the launchd overnight job)
+#
+# The scrape runs under `caffeinate` so idle sleep can't tear the browser down
+# mid-run. `--sleep-after` returns the Mac to sleep once the run + upload finish;
+# omit it for manual daytime runs so your machine isn't slept out from under you.
 #
 # Scheduled via launchd: see infra/linkedin-scraper.plist.example
 # ---------------------------------------------------------------------------
 
 set -euo pipefail
+
+# Pull our own --sleep-after flag out of the args before forwarding the rest to
+# python (main.py uses argparse and would reject an unknown flag).
+SLEEP_AFTER=0
+ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--sleep-after" ]]; then
+        SLEEP_AFTER=1
+    else
+        ARGS+=("$arg")
+    fi
+done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -30,9 +48,18 @@ if [[ -f "$ENV_FILE" ]]; then
 fi
 
 cd "$PROJECT_DIR"
-# `|| EXIT_CODE=$?` keeps set -e from aborting before the footer logs on failure
+# `caffeinate -i` holds an idle-sleep assertion for the lifetime of the scrape
+# (released automatically when python exits) — this is what stops the Mac from
+# sleeping mid-run and killing the browser subprocess.
+# `|| EXIT_CODE=$?` keeps set -e from aborting before the footer logs on failure.
 EXIT_CODE=0
-python3 src/main.py scrape "$@" || EXIT_CODE=$?
+caffeinate -i python3 src/main.py scrape ${ARGS[@]+"${ARGS[@]}"} || EXIT_CODE=$?
 
 echo "===== Scraper finished at $(date -u '+%Y-%m-%d %H:%M:%S UTC') (exit $EXIT_CODE) ====="
+
+if [[ "$SLEEP_AFTER" -eq 1 ]]; then
+    echo "Returning to sleep (pmset sleepnow)."
+    pmset sleepnow || true
+fi
+
 exit $EXIT_CODE

--- a/scripts/setup_wake_schedule.sh
+++ b/scripts/setup_wake_schedule.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# setup_wake_schedule.sh — install the daily wake that lets the scraper run
+#                          unattended overnight.
+#
+# THIS IS THE PIECE launchd CANNOT DO. `StartCalendarInterval` in the plist
+# only runs the job when the Mac is already awake (or on its next wake) — it
+# does NOT wake a sleeping Mac. `pmset repeat wake` schedules an actual
+# hardware wake event so the machine is awake when launchd fires at 22:00.
+#
+# Run ONCE, with sudo (pmset scheduling requires root):
+#   sudo ./scripts/setup_wake_schedule.sh
+#
+# Undo:
+#   sudo pmset repeat cancel
+#
+# Inspect the current schedule any time (no sudo needed):
+#   pmset -g sched
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    echo "This script must be run with sudo (pmset scheduling requires root)." >&2
+    echo "  sudo $0" >&2
+    exit 1
+fi
+
+# Wake every day at 21:58, a 2-minute buffer before the 22:00 launchd job.
+# MTWRFSU = Mon Tue Wed Thu Fri Sat Sun (every day).
+pmset repeat wake MTWRFSU 21:58:00
+
+echo "Daily wake installed. Current schedule:"
+pmset -g sched


### PR DESCRIPTION
Promotes PR #48: restores the wake → scrape → upload → sleep cycle (pmset wake + caffeinate + sleepnow) that fixes the 3 nights of scheduled-run failures.