### PR TITLE
Wall-clock watchdog: a wedged browser can no longer hang the run

### DIFF
--- a/src/browser.py
+++ b/src/browser.py
@@ -30,6 +30,10 @@ def launch(headless: bool = True, block_resources: bool = True):
         viewport={"width": 1440, "height": 900},
         args=["--disable-blink-features=AutomationControlled"],
     )
+    # Bound slow-but-alive pages at the Playwright layer; watchdog.time_limit is
+    # the harder backstop for a wedged driver (which ignores these).
+    context.set_default_navigation_timeout(30_000)
+    context.set_default_timeout(20_000)
     if block_resources:
         context.route("**/*", _block_heavy_resources)
     page = context.pages[0] if context.pages else context.new_page()

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,11 @@ MAX_PAGES = int(os.getenv("MAX_PAGES", "10"))
 MAX_DETAIL_VISITS = int(os.getenv("MAX_DETAIL_VISITS", "300"))  # per-run cap (rate hygiene)
 DETAIL_DELAY_RANGE = (2.0, 5.0)  # jittered seconds between detail-page visits
 
+# --- watchdog: never let a wedged browser hang the run (see watchdog.py) -----
+MAX_RUN_SECONDS = int(os.getenv("MAX_RUN_SECONDS", "1800"))      # whole-run wall-clock cap (30 min)
+DETAIL_VISIT_TIMEOUT = int(os.getenv("DETAIL_VISIT_TIMEOUT", "90"))  # per detail-page hard cap
+HARVEST_PAGE_TIMEOUT = int(os.getenv("HARVEST_PAGE_TIMEOUT", "60"))  # per search-results page hard cap
+
 # --- paths ------------------------------------------------------------------
 DB_PATH = Path(os.getenv("DB_PATH", PROJECT_DIR / "data" / "jobs.db"))
 PROFILE_DIR = Path(os.getenv("PROFILE_DIR", PROJECT_DIR / "chrome_user_data"))

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -11,6 +11,9 @@ import urllib.parse
 
 from playwright.sync_api import Page
 
+import config
+from watchdog import OperationTimeout, time_limit
+
 log = logging.getLogger("crawler")
 
 CARD_SELECTOR = 'div[role="button"][componentkey^="job-card-component-ref-"]'
@@ -73,14 +76,21 @@ def harvest_query(page: Page, query: str, window: str, max_pages: int) -> list[d
     """Paginate through a search query; returns deduped card records."""
     seen: dict[str, dict] = {}
     for page_num in range(max_pages):
-        page.goto(build_search_url(query, window, page_num * PAGE_SIZE), wait_until="domcontentloaded")
         try:
-            page.wait_for_selector(CARD_SELECTOR, timeout=15_000)
-        except Exception:
-            break  # no cards rendered = past the last page
-        page.evaluate(_SCROLL_LIST_JS)
-        page.wait_for_timeout(1_500)
-        cards = page.evaluate(_HARVEST_JS)
+            # Hard cap the whole page so a wedged driver (evaluate has no
+            # Playwright timeout of its own) can't hang harvesting.
+            with time_limit(config.HARVEST_PAGE_TIMEOUT, f"harvest {query!r} page {page_num + 1}"):
+                page.goto(build_search_url(query, window, page_num * PAGE_SIZE), wait_until="domcontentloaded")
+                try:
+                    page.wait_for_selector(CARD_SELECTOR, timeout=15_000)
+                except Exception:
+                    break  # no cards rendered = past the last page
+                page.evaluate(_SCROLL_LIST_JS)
+                page.wait_for_timeout(1_500)
+                cards = page.evaluate(_HARVEST_JS)
+        except OperationTimeout as e:
+            log.warning("%s — stopping pagination for this query", e)
+            break
         log.info("query=%r page=%d cards=%d", query, page_num + 1, len(cards))
         new = [c for c in cards if c["job_id"] not in seen]
         if not new:
@@ -95,10 +105,17 @@ def job_url(job_id: str) -> str:
 
 def extract_sections(page: Page, job_id: str) -> dict:
     """Raw innerText per section + top_card (None where a section is absent,
-    e.g. Premium sections without a subscription)."""
-    page.goto(job_url(job_id), wait_until="domcontentloaded")
-    page.wait_for_selector(f'[componentkey^="{SECTION_PREFIXES["about_job"]}"]', timeout=15_000)
-    for _ in range(4):  # progressive scroll triggers lazy sections (AboutTheCompany, insights)
-        page.mouse.wheel(0, 1_500)
-        page.wait_for_timeout(400)
-    return page.evaluate(_COLLECT_SECTIONS_JS, SECTION_PREFIXES)
+    e.g. Premium sections without a subscription).
+
+    The whole visit is wrapped in a SIGALRM hard cap: `page.evaluate` has no
+    Playwright timeout, so a wedged driver would otherwise block forever here
+    (the 100/300 hang). OperationTimeout surfaces to the per-job retry in
+    main.scrape_details, so one bad job is skipped rather than freezing the run.
+    """
+    with time_limit(config.DETAIL_VISIT_TIMEOUT, f"detail visit {job_id}"):
+        page.goto(job_url(job_id), wait_until="domcontentloaded")
+        page.wait_for_selector(f'[componentkey^="{SECTION_PREFIXES["about_job"]}"]', timeout=15_000)
+        for _ in range(4):  # progressive scroll triggers lazy sections (AboutTheCompany, insights)
+            page.mouse.wheel(0, 1_500)
+            page.wait_for_timeout(400)
+        return page.evaluate(_COLLECT_SECTIONS_JS, SECTION_PREFIXES)

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ import crawler
 import export
 import parsers
 import store
+import watchdog
 from schemas import Job
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s - %(message)s")
@@ -48,10 +49,11 @@ def cmd_login() -> int:
 
 # --- scrape: Phase A (harvest) → diff → Phase B (details) → export ----------
 
-def harvest_cards(page, args) -> dict[str, dict]:
+def harvest_cards(page, args, deadline: watchdog.Deadline) -> dict[str, dict]:
     """Phase A: collect unique cards across all queries, keyed by job_id."""
     cards: dict[str, dict] = {}
     for query in ([args.query] if args.query else config.SCRAPE_QUERIES):
+        deadline.check("harvest")
         for card in crawler.harvest_query(page, query, args.window, args.max_pages):
             cards.setdefault(card["job_id"], card)
     return cards
@@ -85,13 +87,15 @@ def build_job(job_id: str, card: dict, sections: dict, run_dt: datetime, ts: str
     )
     return Job(**{k: v for k, v in fields.items() if k in Job.__dataclass_fields__})
 
-def scrape_details(page, conn, cards: dict[str, dict], new_ids: list[str], run_dt: datetime, ts: str) -> None:
+def scrape_details(page, conn, cards: dict[str, dict], new_ids: list[str], run_dt: datetime, ts: str,
+                   deadline: watchdog.Deadline) -> None:
     """Phase B: visit each new job's page. Commit per job, so a crash resumes."""
     todo = new_ids[: config.MAX_DETAIL_VISITS]
     for i, job_id in enumerate(todo, 1):
+        deadline.check(f"details {i}/{len(todo)}")
         for attempt in (1, 2):
             try:
-                sections = crawler.extract_sections(page, job_id)
+                sections = crawler.extract_sections(page, job_id)  # hard-capped per visit
                 store.upsert_job(conn, build_job(job_id, cards[job_id], sections, run_dt, ts))
                 break
             except Exception as e:
@@ -108,6 +112,7 @@ def cmd_scrape(args) -> int:
     log.info("Run %s | %d jobs already in store", ts, len(known))
 
     pw, context, page = browser.launch(headless=not args.headed)
+    deadline = watchdog.Deadline(config.MAX_RUN_SECONDS)
     status, cards, new_ids = "failed", {}, []
     try:
         browser.start_trace(context)
@@ -115,7 +120,7 @@ def cmd_scrape(args) -> int:
             notify("LinkedIn session expired — run: python src/main.py login")
             return EXIT_NOT_LOGGED_IN
 
-        cards = harvest_cards(page, args)
+        cards = harvest_cards(page, args, deadline)
         if not cards:
             log.error("Zero cards harvested — selectors may have broken")
             notify("Scrape failed: zero job cards found")
@@ -124,8 +129,14 @@ def cmd_scrape(args) -> int:
         new_ids = [jid for jid in cards if jid not in known]
         store.touch_last_seen(conn, [jid for jid in cards if jid in known], ts)
         log.info("Harvested %d cards: %d new, %d already known", len(cards), len(new_ids), len(cards) - len(new_ids))
-        scrape_details(page, conn, cards, new_ids, run_dt, ts)
+        scrape_details(page, conn, cards, new_ids, run_dt, ts, deadline)
         status = "ok"
+    except watchdog.RunAborted as e:
+        # Wall-clock backstop tripped (wedged/slow browser). Fail fast: the
+        # finally below still records the run + trace, and per-job commits mean
+        # everything scraped so far is already persisted and gets exported.
+        log.error("Run aborted by watchdog: %s", e)
+        notify(f"Scrape aborted: {e}")
     finally:
         if status == "ok":  # keep the trace only for failed runs — the cron post-mortem
             browser.discard_trace(context)

--- a/src/watchdog.py
+++ b/src/watchdog.py
@@ -1,0 +1,59 @@
+"""Wall-clock guards so a wedged browser can never hang the whole run.
+
+Playwright's own timeouts are enforced *by the node driver*; if that driver's
+pipe wedges (browser crash / OOM), a sync call like `page.evaluate` — which has
+no timeout at all — blocks forever at 0% CPU. That is the failure that froze a
+run at 100/300 for 8.5h. `time_limit` uses SIGALRM, which interrupts the blocked
+syscall regardless of the driver's state; `Deadline` caps total runtime so a
+long tail of slow-but-not-hung operations can't drain the battery either.
+
+SIGALRM is delivered on the main thread only — both guards must run there (the
+scrape orchestration does).
+"""
+
+import signal
+import time
+from contextlib import contextmanager
+
+
+class OperationTimeout(Exception):
+    """A single browser operation blew its per-call budget (retryable)."""
+
+
+class RunAborted(Exception):
+    """The whole run exceeded its wall-clock budget — stop and clean up."""
+
+
+@contextmanager
+def time_limit(seconds: float, label: str = "operation"):
+    """Raise OperationTimeout if the wrapped block runs past `seconds`.
+
+    Works even when blocked in a C-level syscall (the wedged-pipe case), unlike
+    Playwright's driver-enforced timeouts.
+    """
+    def _fire(signum, frame):
+        raise OperationTimeout(f"{label} exceeded {seconds:g}s")
+
+    previous = signal.signal(signal.SIGALRM, _fire)
+    signal.setitimer(signal.ITIMER_REAL, max(0.001, seconds))
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)  # always disarm
+        signal.signal(signal.SIGALRM, previous)
+
+
+class Deadline:
+    """Whole-run wall-clock budget; call check() at safe points between ops."""
+
+    def __init__(self, seconds: float):
+        self.seconds = seconds
+        self._end = time.monotonic() + seconds
+
+    def check(self, label: str = "") -> None:
+        if time.monotonic() > self._end:
+            where = f" at {label}" if label else ""
+            raise RunAborted(f"run exceeded {self.seconds:g}s budget{where}")
+
+    def remaining(self) -> float:
+        return max(0.0, self._end - time.monotonic())

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,47 @@
+"""The watchdog is the guarantee that a wedged browser can't hang the run,
+so its two failure modes are worth pinning down: a per-op cap that fires even
+inside a blocked syscall, and a whole-run deadline."""
+
+import socket
+import time
+
+import pytest
+
+from watchdog import Deadline, OperationTimeout, RunAborted, time_limit
+
+
+def test_time_limit_interrupts_a_blocked_syscall():
+    # A blocking recv with no data mimics the wedged driver pipe that froze the
+    # real run — Playwright's own timeouts can't touch this; SIGALRM must.
+    a, _b = socket.socketpair()
+    start = time.monotonic()
+    with pytest.raises(OperationTimeout):
+        with time_limit(0.2, "recv"):
+            a.recv(1024)
+    assert time.monotonic() - start < 1.0
+
+
+def test_time_limit_passes_through_when_fast():
+    with time_limit(5, "fast"):
+        result = 1 + 1
+    assert result == 2
+
+
+def test_time_limit_disarms_after_exit():
+    # A stray timer would fire into unrelated later code; ensure it's cleared.
+    with time_limit(0.2, "quick"):
+        pass
+    time.sleep(0.4)  # would raise here if the alarm were still armed
+
+
+def test_deadline_check_raises_once_past_budget():
+    d = Deadline(0.1)
+    time.sleep(0.15)
+    with pytest.raises(RunAborted):
+        d.check("details")
+
+
+def test_deadline_check_silent_within_budget():
+    d = Deadline(60)
+    d.check("harvest")  # plenty of budget left — must not raise
+    assert d.remaining() > 0


### PR DESCRIPTION
## Problem

A manual run froze at detail visit **100/300 for 8.5 hours** at 0% CPU. Diagnosis: Chromium died mid-run and python blocked on Playwright's driver pipe. `page.evaluate` has **no Playwright timeout**, and Playwright's timeouts are enforced *by the node driver* — useless when the driver itself is wedged. `caffeinate` (working as designed) then kept the Mac awake, draining the battery to 10%.

This is distinct from the sleep/wake fix (#48), which was validated in the same run (8h37m awake, zero idle-sleep).

## Fix — two layers

- **`src/watchdog.py`** (new):
  - `time_limit(seconds)` — SIGALRM context manager that interrupts even a **blocked syscall** (verified against a blocked socket recv), which Playwright timeouts cannot.
  - `Deadline(seconds)` — whole-run wall-clock budget, checked between ops.
- **`crawler.py`** — each detail visit (`DETAIL_VISIT_TIMEOUT=90s`) and each harvest page (`HARVEST_PAGE_TIMEOUT=60s`) runs inside `time_limit`; a hung op is skipped/broken, not fatal.
- **`main.cmd_scrape`** — runs under `Deadline(MAX_RUN_SECONDS=1800)`; catches `RunAborted` to **fail fast**: records the failed run + trace, and still exports partial data (per-job commits mean nothing scraped is lost).
- **`browser.launch`** — explicit default nav/action timeouts as defense-in-depth for slow-but-alive pages.

## Verification

- 125 tests pass (5 new watchdog tests, incl. interrupting a blocked syscall + whole-run deadline).
- All edited modules import cleanly; config values load.
- Full live rerun to follow.