### PR TITLE
Consolidate daily-trigger setup: install_daily_trigger.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,16 @@ python src/main.py export --date 2026-07-18                    # re-export a day
 
 AWS credentials (`aws configure`) are needed only for exports (S3 write + SSM read of the HF token).
 
-**Schedule (unattended overnight run):** three pieces, because launchd alone does *not* wake a sleeping Mac — it only runs the job once the machine is awake.
+**Schedule (unattended overnight run):** two one-time commands, because launchd alone does *not* wake a sleeping Mac — it only runs the job once the machine is awake.
 
-1. **Wake** — install a daily hardware wake once: `sudo ./scripts/setup_wake_schedule.sh` (`pmset repeat wake` at 21:58; undo with `sudo pmset repeat cancel`, inspect with `pmset -g sched`).
-2. **Run** — copy `infra/linkedin-scraper.plist.example` to `~/Library/LaunchAgents/`, fix the two paths, `launchctl load` it. launchd fires `run_daily.sh --sleep-after` at 22:00; output lands in `logs/scrape.log`.
-3. **Stay awake, then sleep** — the wrapper runs the scrape under `caffeinate` so idle sleep can't kill it mid-run, then `--sleep-after` returns the Mac to sleep once the upload finishes (manual runs omit the flag, so they never sleep your machine).
+```bash
+./scripts/install_daily_trigger.sh        # launchd job @ 22:00 (no sudo; idempotent — rerun after pulling)
+sudo ./scripts/setup_wake_schedule.sh     # pmset wake @ 21:58 so the Mac is awake when the job fires
+```
+
+- **Wake** — `setup_wake_schedule.sh` installs `pmset repeat wake` at 21:58 (undo with `sudo pmset repeat cancel`, inspect with `pmset -g sched`). **Without this, the job only runs if the Mac is already awake at 22:00; a sleeping Mac won't wake, and a shut-down Mac won't power on.**
+- **Run** — `install_daily_trigger.sh` renders the plist for this checkout, replaces any older copy, and loads it; launchd fires `run_daily.sh --sleep-after` at 22:00 → `logs/scrape.log`.
+- **Stay awake, then sleep** — the wrapper runs the scrape under `caffeinate` so idle sleep can't kill it mid-run, then `--sleep-after` returns the Mac to sleep once the upload finishes (manual runs omit the flag, so they never sleep your machine).
 
 Failed runs save a Playwright trace to `logs/traces/` — inspect with `playwright show-trace <file>`.
 

--- a/infra/linkedin-scraper.plist.example
+++ b/infra/linkedin-scraper.plist.example
@@ -11,10 +11,9 @@
   The wrapper then runs the scrape under `caffeinate` (stays awake through the
   upload) and, because of the --sleep-after arg below, sleeps the Mac when done.
 
-  Install:
-    cp infra/linkedin-scraper.plist.example ~/Library/LaunchAgents/com.<you>.linkedin-scraper.plist
-    # edit the two /path/to/ds_jobs paths below, then:
-    launchctl load ~/Library/LaunchAgents/com.<you>.linkedin-scraper.plist
+  Install: don't copy this by hand — run the installer, which renders the two
+  /path/to/ds_jobs paths and the Label for this checkout, then (re)loads it:
+    ./scripts/install_daily_trigger.sh
 -->
 <plist version="1.0">
 <dict>

--- a/scripts/install_daily_trigger.sh
+++ b/scripts/install_daily_trigger.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# install_daily_trigger.sh — install (or refresh) the launchd job that runs the
+#                            scraper at 22:00 daily.
+#
+# Renders infra/linkedin-scraper.plist.example with this checkout's real path,
+# installs it to ~/Library/LaunchAgents, removes any older copy, and (re)loads
+# it. Idempotent — safe to run again after pulling changes to the template or
+# run_daily.sh. Runs as your normal user; NO sudo (LaunchAgents load in your
+# GUI session, not as root).
+#
+# This is only the "when awake, run the job" half. launchd does NOT wake a
+# sleeping Mac — install the daily wake once, separately:
+#     sudo ./scripts/setup_wake_schedule.sh
+#
+# Usage:
+#     ./scripts/install_daily_trigger.sh
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+TEMPLATE="$PROJECT_DIR/infra/linkedin-scraper.plist.example"
+AGENTS="$HOME/Library/LaunchAgents"
+LABEL="com.$(id -un).linkedin-scraper"
+DEST="$AGENTS/$LABEL.plist"
+UID_NUM="$(id -u)"
+
+mkdir -p "$AGENTS"
+
+# Remove any existing linkedin-scraper agent (incl. a stale label from an
+# earlier install) so we never end up with two jobs firing.
+for old in "$AGENTS"/*linkedin-scraper*.plist; do
+    [[ -e "$old" ]] || continue
+    old_label="$(basename "$old" .plist)"
+    launchctl bootout "gui/$UID_NUM/$old_label" 2>/dev/null || true
+    rm -f "$old"
+    echo "removed old agent: $old_label"
+done
+
+# Render the template with this checkout's real path + a per-user label.
+sed -e "s#/path/to/ds_jobs#$PROJECT_DIR#g" \
+    -e "s#com\.user\.linkedin-scraper#$LABEL#g" \
+    "$TEMPLATE" > "$DEST"
+
+launchctl bootstrap "gui/$UID_NUM" "$DEST"
+echo "installed + loaded: $DEST"
+echo
+
+launchctl print "gui/$UID_NUM/$LABEL" 2>/dev/null | grep -E "state =|program =|--sleep-after" || true
+echo
+echo "Next (one time, needs sudo — the piece launchd can't do):"
+echo "    sudo $SCRIPT_DIR/setup_wake_schedule.sh    # wakes the Mac at 21:58 so the 22:00 job can run while asleep"
+echo "Verify the wake with:  pmset -g sched"


### PR DESCRIPTION
## Why

Verified on the live machine: the installed launchd plist (`com.ryang2.linkedin-scraper`) had drifted from the repo template — **missing `--sleep-after`** — and no `pmset` wake was installed, so nightly runs only fired because the Mac happened to be awake at 22:00. Setup was also a manual copy-and-sed-the-paths dance.

## Change

- **`scripts/install_daily_trigger.sh`** (new): renders the plist template with this checkout's real path + a per-user Label, **removes any older/stale copy** (so only one job is ever loaded), and (re)loads via `launchctl bootstrap`. Idempotent, no sudo.
- **plist template + README**: daily setup is now two clear one-time commands — `install_daily_trigger.sh` (launchd, no sudo) + `setup_wake_schedule.sh` (pmset wake, sudo). README now states plainly that an asleep Mac needs the wake and a **shut-down Mac won't power on**.

## Verified live

Ran the installer: removed stale `com.ryang2`, installed `com.ruichenyang.linkedin-scraper` **with `--sleep-after`**, exactly one job loaded, `plutil -lint` OK, real paths rendered.