### PR TITLE
info_extractor: add store.py (job_skills read/write layer)

### DIFF
--- a/info_extractor/src/store.py
+++ b/info_extractor/src/store.py
@@ -1,0 +1,91 @@
+"""SQLite persistence for extracted JobSkills.
+
+Writes one `job_skills` row per posting into the shared `data/jobs.db`: the
+scraper owns `jobs`, this module owns `job_skills`, keyed `job_id` back to it.
+Reads `jobs.job_description` via raw SQL (no import of the scraper's schema) so
+the component stays self-contained.
+"""
+
+import json
+import sqlite3
+import typing
+from pathlib import Path
+
+from schema import JOBSKILLS_FIELDS, SCHEMA_VERSION, JobSkills
+
+# Wait out the scraper's writes on the shared file instead of erroring — an
+# operational knob peer to the WAL pragma, not a tunable business setting.
+_BUSY_TIMEOUT_MS = 5000
+
+# List-typed fields have no SQLite array type → stored as JSON text.
+_JSON_FIELDS = {
+    name for name, field in JobSkills.model_fields.items()
+    if typing.get_origin(field.annotation) is list
+}
+
+
+def _sqlite_type(annotation) -> str:
+    """SQLite affinity for a JobSkills field: INTEGER for ints, else TEXT.
+
+    Enums store as their `.value` string and lists as JSON text — both TEXT.
+    Unwraps `Optional[...]` to the underlying type first.
+    """
+    args = [a for a in typing.get_args(annotation) if a is not type(None)]
+    base = args[0] if args else annotation
+    return "INTEGER" if base is int else "TEXT"
+
+
+_COLUMNS = ", ".join(
+    f"{name} {_sqlite_type(field.annotation)}" + (" PRIMARY KEY" if name == "job_id" else "")
+    for name, field in JobSkills.model_fields.items()
+)
+_CREATE_JOB_SKILLS = f"CREATE TABLE IF NOT EXISTS job_skills ({_COLUMNS})"
+
+# Re-extraction fully overwrites the record (nothing to preserve, unlike the
+# scraper's first_seen/times_seen), so REPLACE is the idempotent write.
+_INSERT_SKILLS = (
+    f"INSERT OR REPLACE INTO job_skills ({', '.join(JOBSKILLS_FIELDS)}) "
+    f"VALUES ({', '.join(f':{f}' for f in JOBSKILLS_FIELDS)})"
+)
+
+# Postings needing extraction: have a description, and either no job_skills row
+# or one written under an older schema. LIMIT -1 means unbounded.
+_CANDIDATES = """SELECT j.job_id, j.job_description
+FROM jobs j LEFT JOIN job_skills s ON s.job_id = j.job_id
+WHERE j.job_description IS NOT NULL AND j.job_description != ''
+  AND (s.job_id IS NULL OR s.schema_version < :schema_version)
+ORDER BY j.job_id LIMIT :limit"""
+
+
+def connect(db_path: str | Path) -> sqlite3.Connection:
+    """Open the shared DB and ensure the `job_skills` table exists.
+
+    Creates only `job_skills` — the scraper owns `jobs`. No mkdir: `data/`
+    already exists, and running before the scraper fails loudly on the missing
+    `jobs` table (which is the correct signal).
+    """
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
+    conn.execute(_CREATE_JOB_SKILLS)
+    conn.commit()
+    return conn
+
+
+def candidates(conn: sqlite3.Connection, limit: int | None = None) -> list[tuple[str, str]]:
+    """(job_id, job_description) for postings not yet extracted at this schema."""
+    params = {"schema_version": SCHEMA_VERSION, "limit": -1 if limit is None else limit}
+    return conn.execute(_CANDIDATES, params).fetchall()
+
+
+def write_skills(conn: sqlite3.Connection, records: typing.Iterable[JobSkills]) -> int:
+    """Bulk-upsert JobSkills, idempotent by job_id. Returns the number written."""
+    rows = []
+    for record in records:
+        row = record.model_dump(mode="json")  # enums -> .value strings
+        for field in _JSON_FIELDS:
+            row[field] = json.dumps(row[field])
+        rows.append(row)
+    conn.executemany(_INSERT_SKILLS, rows)
+    conn.commit()
+    return len(rows)

--- a/info_extractor/tests/test_store.py
+++ b/info_extractor/tests/test_store.py
@@ -1,0 +1,79 @@
+"""Offline tests for store.py against an in-memory SQLite DB (no shared file)."""
+
+import json
+import sqlite3
+
+import pytest
+
+import store
+from schema import SCHEMA_VERSION, JobSkills
+
+# Minimal stand-in for the scraper's `jobs` table — only the columns store.py
+# reads. (id, description, expected-to-be-a-candidate)
+_SEED_JOBS = [
+    ("1", "Senior MLE, must have Python", True),
+    ("2", "Data Scientist, SQL and stats", True),
+    ("3", None, False),   # no description -> never a candidate
+    ("4", "", False),     # empty description -> never a candidate
+]
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.execute("CREATE TABLE jobs (job_id TEXT PRIMARY KEY, job_description TEXT)")
+    c.executemany(
+        "INSERT INTO jobs (job_id, job_description) VALUES (?, ?)",
+        [(jid, desc) for jid, desc, _ in _SEED_JOBS],
+    )
+    c.commit()
+    c.execute(store._CREATE_JOB_SKILLS)  # same table store.connect() would create
+    c.commit()
+    return c
+
+
+def _ids(rows) -> set[str]:
+    return {job_id for job_id, _ in rows}
+
+
+def test_connect_is_idempotent(tmp_path):
+    db = tmp_path / "jobs.db"
+    store.connect(db).close()
+    store.connect(db).close()  # second create must not raise
+    with sqlite3.connect(db) as c:
+        assert c.execute("SELECT name FROM sqlite_master WHERE name='job_skills'").fetchone()
+
+
+def test_candidates_needs_nonempty_description(conn):
+    assert _ids(store.candidates(conn)) == {"1", "2"}  # 3 (NULL) and 4 ("") excluded
+
+
+def test_candidates_excludes_current_schema_and_includes_stale(conn):
+    store.write_skills(conn, [JobSkills(job_id="1")])                    # current schema
+    conn.execute("UPDATE job_skills SET schema_version = ? WHERE job_id = '1'", (SCHEMA_VERSION - 1,))
+    assert "1" in _ids(store.candidates(conn))                           # stale -> re-extract
+    store.write_skills(conn, [JobSkills(job_id="1")])                    # refresh to current
+    assert "1" not in _ids(store.candidates(conn))                       # current -> done
+
+
+def test_candidates_limit_caps_count(conn):
+    assert len(store.candidates(conn, limit=1)) == 1
+
+
+def test_write_skills_roundtrip_serializes_enums_and_lists(conn):
+    record = JobSkills(job_id="1", role_family="MLE", modeling_area=["NLP", "RAG"], must_have_skills=["Python"])
+    assert store.write_skills(conn, [record]) == 1
+
+    role_family, modeling_area, must_have = conn.execute(
+        "SELECT role_family, modeling_area, must_have_skills FROM job_skills WHERE job_id='1'"
+    ).fetchone()
+    assert role_family == "MLE"                       # enum -> plain string
+    assert json.loads(modeling_area) == ["NLP", "RAG"]  # list -> JSON text
+    assert json.loads(must_have) == ["Python"]
+
+
+def test_write_skills_overwrites_by_job_id(conn):
+    store.write_skills(conn, [JobSkills(job_id="1", seniority="mid")])
+    store.write_skills(conn, [JobSkills(job_id="1", seniority="senior")])
+    rows = conn.execute("SELECT seniority FROM job_skills WHERE job_id='1'").fetchall()
+    assert rows == [("senior",)]  # one row, latest value (INSERT OR REPLACE)


### PR DESCRIPTION
Adds the DB read/write layer for the info_extractor.

- `connect()` — WAL + busy_timeout, creates the `job_skills` table (scraper owns `jobs`)
- `candidates()` — postings needing extraction (un-extracted or stale `schema_version`)
- `write_skills()` — idempotent bulk `INSERT OR REPLACE`, enums→str, lists→JSON

Column types + JSON-list fields reflected from `JobSkills.model_fields` (schema.py stays the single source of truth). 6 offline tests (in-memory SQLite); full suite 13 green. Smoke-tested against the real 50k-row `data/jobs.db`.