### PR TITLE
info_extractor: local Ollama extraction pipeline

### DIFF
--- a/info_extractor/.env.example
+++ b/info_extractor/.env.example
@@ -4,16 +4,12 @@
 # Path to the shared SQLite DB the scraper writes (relative to info_extractor/).
 DB_PATH=../data/jobs.db
 
-# Models
-EXTRACT_MODEL=claude-haiku-4-5
-EXTRACT_VALIDATION_MODEL=claude-opus-4-8
+# Local LLM (Ollama). Start the daemon and `ollama pull` the model first.
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODEL=qwen2.5:14b
 
-# Batch / request tuning
-EXTRACT_BATCH_SIZE=500
-EXTRACT_MAX_TOKENS=1024
+# Request / run tuning
 EXTRACT_MAX_DESC_CHARS=8000
-EXTRACT_POLL_SECONDS=30
+EXTRACT_REQUEST_TIMEOUT=120
+EXTRACT_COMMIT_CHUNK=25
 EXTRACT_MAX_RUN_SECONDS=7200
-
-# Secret — needed for real runs only; read by the Anthropic SDK from the env.
-# ANTHROPIC_API_KEY=sk-ant-...

--- a/info_extractor/src/config.py
+++ b/info_extractor/src/config.py
@@ -2,9 +2,8 @@
 
 Every operational setting is read from info_extractor/.env (see .env.example) —
 there are no in-code defaults, so a missing key fails loudly at import instead of
-silently running on a guessed value. The Anthropic API key is not read here; the
-SDK picks it up from the environment at call time (so offline tests and
---dry-run don't need it).
+silently running on a guessed value. Extraction runs on a local Ollama model, so
+there is no API key or cost — just a running daemon with the model pulled.
 """
 
 import os
@@ -28,13 +27,12 @@ def _require(name: str) -> str:
 # dir (absolute paths in .env also work).
 DB_PATH = (_COMPONENT_DIR / _require("DB_PATH")).resolve()
 
-# Models: Haiku is the daily batch workhorse; Opus audits a validation sample.
-EXTRACT_MODEL = _require("EXTRACT_MODEL")
-VALIDATION_MODEL = _require("EXTRACT_VALIDATION_MODEL")
+# Local LLM (Ollama) — free, private, no API key.
+OLLAMA_HOST = _require("OLLAMA_HOST")
+OLLAMA_MODEL = _require("OLLAMA_MODEL")
 
-# Batch / request tuning.
-BATCH_SIZE = int(_require("EXTRACT_BATCH_SIZE"))                    # rows per Batch submission
-MAX_OUTPUT_TOKENS = int(_require("EXTRACT_MAX_TOKENS"))            # one JobSkills record is small
+# Request / run tuning.
 MAX_DESCRIPTION_CHARS = int(_require("EXTRACT_MAX_DESC_CHARS"))    # trim to bound input tokens
-POLL_SECONDS = int(_require("EXTRACT_POLL_SECONDS"))              # batch-status poll interval
+REQUEST_TIMEOUT = int(_require("EXTRACT_REQUEST_TIMEOUT"))        # per-posting inference cap (s)
+COMMIT_CHUNK = int(_require("EXTRACT_COMMIT_CHUNK"))              # rows written per transaction
 MAX_RUN_SECONDS = int(_require("EXTRACT_MAX_RUN_SECONDS"))         # whole-run wall-clock cap

--- a/info_extractor/src/extract.py
+++ b/info_extractor/src/extract.py
@@ -1,0 +1,98 @@
+"""Local (Ollama) skill/competency extraction pipeline.
+
+Synchronous loop — no Batch API. For each posting that needs extraction, ask the
+local model to fill the JobSkills schema (enforced via Ollama's structured-output
+`format`), validate the result with Pydantic, stamp provenance we own, and bulk-
+write in chunks. Resumable: `store.candidates` re-derives the outstanding set, so
+a killed run just leaves rows for the next.
+"""
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+
+import ollama
+
+import config
+import prompt
+import store
+from schema import JobSkills
+
+log = logging.getLogger("extract")
+
+# The model fills the JobSkills fields except these — job_id comes from the DB and
+# provenance is stamped by us, so they're pruned from the schema the model sees.
+_OWNED_FIELDS = {"job_id", "extract_model", "extract_dt", "schema_version"}
+
+
+def _model_schema() -> dict:
+    """JobSkills' JSON schema minus the fields we own — the extraction contract
+    handed to Ollama's `format`. Enum `$defs` stay (still referenced by the kept
+    fields), so the model is constrained to valid enum values."""
+    schema = JobSkills.model_json_schema()
+    schema["properties"] = {k: v for k, v in schema["properties"].items() if k not in _OWNED_FIELDS}
+    if "required" in schema:
+        schema["required"] = [r for r in schema["required"] if r not in _OWNED_FIELDS]
+    return schema
+
+
+_FORMAT = _model_schema()
+
+
+def make_client() -> ollama.Client:
+    """Ollama client bound to the configured host + per-request timeout."""
+    return ollama.Client(host=config.OLLAMA_HOST, timeout=config.REQUEST_TIMEOUT)
+
+
+def extract_one(client: ollama.Client, model: str, job_id: str, description: str) -> JobSkills | None:
+    """Extract one posting → validated JobSkills, or None on failure (logged).
+
+    A single bad posting (model error, malformed JSON, schema violation) is
+    skipped so it can't kill the run; it reappears in the next candidates() pass.
+    """
+    messages = [{"role": "system", "content": prompt.SYSTEM}]
+    messages += prompt.build_messages(description[: config.MAX_DESCRIPTION_CHARS])
+    try:
+        resp = client.chat(model=model, messages=messages, format=_FORMAT, options={"temperature": 0})
+        # The model fills only the pruned fields; add the ones we own, then let
+        # JobSkills validate the whole record (enum/type checks included).
+        fields = json.loads(resp.message.content)
+        fields.update(
+            job_id=job_id,
+            extract_model=model,
+            extract_dt=datetime.now(timezone.utc).isoformat(),
+        )
+        return JobSkills.model_validate(fields)
+    except Exception as e:  # ollama/network error, invalid JSON, or schema violation
+        log.warning("job %s extraction failed: %s", job_id, e)
+        return None
+
+
+def run(conn, limit: int | None = None, model: str | None = None) -> int:
+    """Extract all candidate postings; bulk-write every COMMIT_CHUNK. Returns count."""
+    model = model or config.OLLAMA_MODEL
+    rows = store.candidates(conn, limit=limit)
+    log.info("Extract | model=%s | %d postings to process", model, len(rows))
+
+    client = make_client()
+    deadline = time.monotonic() + config.MAX_RUN_SECONDS
+    buffer: list[JobSkills] = []
+    written = failed = 0
+    for i, (job_id, description) in enumerate(rows, 1):
+        if time.monotonic() > deadline:
+            log.warning("run budget (%ds) reached at %d/%d — stopping", config.MAX_RUN_SECONDS, i - 1, len(rows))
+            break
+        record = extract_one(client, model, job_id, description)
+        if record is None:
+            failed += 1
+            continue
+        buffer.append(record)
+        if len(buffer) >= config.COMMIT_CHUNK:
+            written += store.write_skills(conn, buffer)
+            buffer.clear()
+            log.info("progress %d/%d (written=%d failed=%d)", i, len(rows), written, failed)
+    if buffer:
+        written += store.write_skills(conn, buffer)
+    log.info("Done: wrote %d, failed %d, of %d candidates", written, failed, len(rows))
+    return written

--- a/info_extractor/src/main.py
+++ b/info_extractor/src/main.py
@@ -1,0 +1,57 @@
+"""info_extractor entry point: python src/main.py extract [...].
+
+Run from the component dir (pytest/pythonpath = src), e.g.
+    python info_extractor/src/main.py extract --limit 5
+Requires a running Ollama daemon with the configured model pulled.
+"""
+
+import argparse
+import logging
+
+import config
+import extract
+import prompt
+import store
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s - %(message)s")
+log = logging.getLogger("main")
+
+
+def cmd_extract(args) -> int:
+    conn = store.connect(config.DB_PATH)
+    model = args.model or config.OLLAMA_MODEL
+
+    if args.dry_run:
+        rows = store.candidates(conn, limit=args.limit)
+        print(f"model         : {model}")
+        print(f"candidates    : {len(rows)} postings need extraction")
+        if rows:
+            job_id, description = rows[0]
+            messages = [{"role": "system", "content": prompt.SYSTEM}]
+            messages += prompt.build_messages(description[: config.MAX_DESCRIPTION_CHARS])
+            print(f"\n--- sample request (job {job_id}) ---")
+            for m in messages:
+                print(f"[{m['role']}]\n{m['content'][:600]}\n")
+        return 0
+
+    extract.run(conn, limit=args.limit, model=args.model)
+    return 0
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(prog="info_extractor", description="Local LLM job-skill extraction")
+    sub = p.add_subparsers(dest="command", required=True)
+    ex = sub.add_parser("extract", help="Extract JobSkills from postings needing it")
+    ex.add_argument("--limit", type=int, default=None, help="Max postings this run (default: all)")
+    ex.add_argument("--model", default=None, help="Override OLLAMA_MODEL for this run")
+    ex.add_argument("--dry-run", action="store_true", help="Show candidate count + one rendered request; no inference")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    return cmd_extract(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/info_extractor/tests/test_extract.py
+++ b/info_extractor/tests/test_extract.py
@@ -1,0 +1,44 @@
+"""Offline tests for the extraction loop — the Ollama client is faked, so no
+daemon or model is needed."""
+
+from types import SimpleNamespace
+
+import extract
+from schema import JobSkills, RoleFamily
+
+
+class _FakeClient:
+    """Stands in for ollama.Client; returns a canned content string per call."""
+
+    def __init__(self, content: str):
+        self._content = content
+
+    def chat(self, **kwargs):  # signature-compatible with ollama.Client.chat
+        return SimpleNamespace(message=SimpleNamespace(content=self._content))
+
+
+_VALID = '{"canonical_title": "ML Engineer", "role_family": "MLE", "seniority": "senior", ' \
+         '"years_experience_min": 5, "modeling_area": ["NLP"], "must_have_skills": ["Python"], ' \
+         '"nice_to_have_skills": [], "tools": ["PyTorch"], "education_req": "Masters", "domain": ["ads"]}'
+
+
+def test_model_schema_excludes_owned_fields():
+    props = extract._FORMAT["properties"]
+    for owned in ("job_id", "extract_model", "extract_dt", "schema_version"):
+        assert owned not in props
+    assert "role_family" in props  # model-filled fields remain
+
+
+def test_extract_one_validates_and_stamps_provenance():
+    js = extract.extract_one(_FakeClient(_VALID), "qwen2.5:14b", "job-123", "some description")
+    assert isinstance(js, JobSkills)
+    assert js.job_id == "job-123"                 # authoritative, not from the model
+    assert js.role_family is RoleFamily.MLE
+    assert js.extract_model == "qwen2.5:14b"
+    assert js.extract_dt                          # stamped
+
+
+def test_extract_one_returns_none_on_bad_output():
+    assert extract.extract_one(_FakeClient("not json"), "m", "job-1", "d") is None
+    bad_enum = '{"role_family": "Wizard"}'
+    assert extract.extract_one(_FakeClient(bad_enum), "m", "job-2", "d") is None

--- a/info_extractor/tests/test_info_extractor.py
+++ b/info_extractor/tests/test_info_extractor.py
@@ -36,6 +36,7 @@ def test_build_messages_is_single_user_turn_with_description():
 
 
 def test_config_is_populated_from_env():
-    assert config.EXTRACT_MODEL           # loaded from .env.example via conftest
-    assert config.BATCH_SIZE > 0
+    assert config.OLLAMA_MODEL            # loaded from .env.example via conftest
+    assert config.OLLAMA_HOST.startswith("http")
+    assert config.COMMIT_CHUNK > 0
     assert str(config.DB_PATH).endswith("data/jobs.db")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ datasets
 huggingface_hub
 pydantic
 python-dotenv
+ollama
 pytest


### PR DESCRIPTION
Free/private skill-competency extraction on a local Ollama model (no API key, no cost, data stays local).

## What
- **config.py / .env.example:** Anthropic keys → Ollama (`OLLAMA_HOST`/`OLLAMA_MODEL`, request timeout, commit chunk, run cap); still fail-fast, no defaults.
- **extract.py:** synchronous loop. Per posting: `chat()` with a **pruned** JobSkills schema as structured-output `format` (job_id + provenance are ours, not the model's) → `json.loads` → stamp `job_id`/`extract_model`/`extract_dt` → `JobSkills.model_validate`. Bad output skipped + logged. Bulk-write every `COMMIT_CHUNK`; resumable via `store.candidates`; optional wall-clock cap.
- **main.py:** component entry — `extract [--limit] [--model] [--dry-run]`.
- **requirements:** `ollama`.
- **tests:** mocked-client extraction tests (offline).

Reuses existing `schema.py` (contract), `prompt.py` (SYSTEM + build_messages), `store.py` (candidates/write_skills) unchanged.

## Verified
16 tests pass; `--dry-run` renders a real request against the shared DB; a live 2-posting run wrote validated rows (0 failed).

⚠️ **Model choice matters:** `gemma4:e4b` gave weak judgment (empty skills, `role_family=Other`). Default is **`qwen2.5:14b`** — `ollama pull qwen2.5:14b` before a real backfill.