### PR TITLE
info_extractor: revert default model to qwen2.5:14b

### DIFF
--- a/info_extractor/.env.example
+++ b/info_extractor/.env.example
@@ -6,7 +6,7 @@ DB_PATH=../data/jobs.db
 
 # Local LLM (Ollama). Start the daemon and `ollama pull` the model first.
 OLLAMA_HOST=http://localhost:11434
-OLLAMA_MODEL=qwen3:30b
+OLLAMA_MODEL=qwen2.5:14b
 
 # Request / run tuning
 EXTRACT_MAX_DESC_CHARS=8000


### PR DESCRIPTION
qwen3:30b (18 GB) can't be pulled — disk is 100% full — and qwen2.5:14b is already good after the prompt fix. Revert the default to the installed, working model. One-line `.env.example` change; 16 tests pass. Revisit qwen3 once real disk space is freed.